### PR TITLE
Add debounced coin search to AddHoldingForm

### DIFF
--- a/lib/searchCoins.ts
+++ b/lib/searchCoins.ts
@@ -1,0 +1,33 @@
+let searchCache: Record<string, {
+  id: string;
+  name: string;
+  symbol: string;
+  image: string;
+}[]> = {};
+
+export async function searchCoins(query: string) {
+  const q = query.toLowerCase().trim();
+  if (!q) return [];
+  if (searchCache[q]) return searchCache[q];
+  try {
+    const res = await fetch(
+      `https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(q)}`
+    );
+    const data = await res.json();
+    const coins = (data.coins || []).map((coin: any) => ({
+      id: coin.id,
+      name: coin.name,
+      symbol: coin.symbol,
+      image: coin.thumb,
+    }));
+    searchCache[q] = coins;
+    return coins;
+  } catch (error) {
+    console.error("Fehler beim Suchen der Coins:", error);
+    return [];
+  }
+}
+
+export function clearSearchCache() {
+  searchCache = {};
+}


### PR DESCRIPTION
## Summary
- Replace initial coin list with a debounced search input for adding holdings
- Cache and fetch coin suggestions from CoinGecko `/search` endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration, execution halted)*

------
https://chatgpt.com/codex/tasks/task_e_689b22c892d08329963ebde5686e5e35