### PR TITLE
Add portfolio summary component with daily performance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Portfolio from "../components/Portfolio";
 import AddHoldingForm from "../components/AddHoldingForm";
+import PortfolioSummary from "../components/PortfolioSummary";
 import { fetchExchangeRate } from "../lib/fetchExchangeRate";
 
 export default function Home() {
@@ -58,6 +59,7 @@ export default function Home() {
         </button>
       </div>
 
+      <PortfolioSummary currency={currency} exchangeRate={exchangeRate} />
       <AddHoldingForm currency={currency} />
       <Portfolio currency={currency} exchangeRate={exchangeRate} />
     </main>

--- a/components/PortfolioSummary.tsx
+++ b/components/PortfolioSummary.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "../lib/supabaseClient";
+import { fetchCoinList } from "../lib/fetchCoinList";
+import { formatCurrency } from "../utils/formatCurrency";
+
+type Holding = {
+  id: string;
+  symbol: string;
+  amount: number;
+  price: number;
+};
+
+type CoinData = {
+  symbol: string;
+  current_price: number;
+  price_change_percentage_24h: number;
+};
+
+type Props = {
+  currency: "eur" | "usd";
+  exchangeRate: number;
+};
+
+export default function PortfolioSummary({ currency, exchangeRate }: Props) {
+  const [holdings, setHoldings] = useState<Holding[]>([]);
+  const [coins, setCoins] = useState<CoinData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadData = async () => {
+      const { data } = await supabase.from("portfolio").select("*");
+      setHoldings((data as Holding[]) || []);
+
+      const list = await fetchCoinList("eur"); // CoinGecko nur in EUR
+      setCoins(list as CoinData[]);
+
+      setLoading(false);
+    };
+
+    loadData();
+  }, []);
+
+  const adjusted = (value: number) =>
+    currency === "eur" ? value : value * exchangeRate;
+
+  const getCoin = (symbol: string) =>
+    coins.find((c) => c.symbol.toLowerCase() === symbol.toLowerCase());
+
+  const totalValue = holdings.reduce((sum, h) => {
+    const coin = getCoin(h.symbol);
+    if (!coin) return sum;
+    return sum + adjusted(coin.current_price) * h.amount;
+  }, 0);
+
+  const totalInvested = holdings.reduce(
+    (sum, h) => sum + adjusted(h.price) * h.amount,
+    0
+  );
+
+  const profitLoss = totalValue - totalInvested;
+
+  const dailyChange = holdings.reduce((sum, h) => {
+    const coin = getCoin(h.symbol);
+    if (!coin) return sum;
+    return (
+      sum +
+      adjusted(coin.current_price) * h.amount *
+        (coin.price_change_percentage_24h / 100)
+    );
+  }, 0);
+
+  const dailyClass = dailyChange >= 0 ? "text-green-500" : "text-red-500";
+  const plClass = profitLoss >= 0 ? "text-green-500" : "text-red-500";
+
+  if (loading) {
+    return <div className="card p-4 text-center">🔄 Lade Zusammenfassung...</div>;
+  }
+
+  return (
+    <div className="card p-4 text-center space-y-2">
+      <div className="text-2xl font-bold">
+        Gesamtwert: {formatCurrency(totalValue, currency)}
+      </div>
+      <div className={`text-xl ${dailyClass}`}>
+        Tagesperformance: {dailyChange >= 0 ? "▲" : "▼"} {formatCurrency(dailyChange, currency)}
+      </div>
+      <div className={`text-xl ${plClass}`}>
+        Gewinn/Verlust: {profitLoss >= 0 ? "▲" : "▼"} {formatCurrency(profitLoss, currency)}
+      </div>
+    </div>
+  );
+}
+

--- a/lib/fetchCoinList.ts
+++ b/lib/fetchCoinList.ts
@@ -4,6 +4,7 @@ let coinListCache: {
   name: string;
   image: string;
   current_price: number;
+  price_change_percentage_24h: number;
 }[] | null = null;
 
 export async function fetchCoinList(currency: "eur" | "usd" = "eur") {
@@ -21,6 +22,7 @@ export async function fetchCoinList(currency: "eur" | "usd" = "eur") {
       name: coin.name,
       image: coin.image,
       current_price: coin.current_price,
+      price_change_percentage_24h: coin.price_change_percentage_24h,
     }));
 
     if (currency === "eur") {


### PR DESCRIPTION
## Summary
- add PortfolioSummary component highlighting total value, daily change and profit/loss
- render portfolio summary above AddHoldingForm on home page
- extend coin list fetch to include 24h price change data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689b22c9e6a883299e5209d2f9e90aaa