### PR TITLE
Add skeleton loaders and fade transitions

### DIFF
--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -31,6 +31,7 @@ export default function Portfolio({ currency, exchangeRate }: Props) {
   const [holdings, setHoldings] = useState<Holding[]>([]);
   const [coinList, setCoinList] = useState<CoinData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fadeIn, setFadeIn] = useState(false);
 
   useEffect(() => {
     const fetchHoldingsAndCoins = async () => {
@@ -48,6 +49,15 @@ export default function Portfolio({ currency, exchangeRate }: Props) {
 
     fetchHoldingsAndCoins();
   }, []);
+
+  useEffect(() => {
+    if (!loading) {
+      const t = setTimeout(() => setFadeIn(true), 50);
+      return () => clearTimeout(t);
+    } else {
+      setFadeIn(false);
+    }
+  }, [loading]);
 
   const getCoinData = (symbol: string): CoinData | undefined =>
     coinList.find((coin) => coin.symbol.toLowerCase() === symbol.toLowerCase());
@@ -93,8 +103,18 @@ export default function Portfolio({ currency, exchangeRate }: Props) {
       setHoldings((prev) => prev.filter((h) => h.id !== id));
     }
   };
-
-  if (loading) return <p>🔄 Lade dein Portfolio...</p>;
+  if (loading)
+    return (
+      <div className="space-y-4 animate-pulse">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-8 bg-gray-200 dark:bg-gray-700 rounded"
+          />
+        ))}
+        <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    );
 
   const coinSymbols = Object.keys(groupedHoldings).filter(
     (symbol) => groupedHoldings[symbol].amount > 0
@@ -103,7 +123,11 @@ export default function Portfolio({ currency, exchangeRate }: Props) {
   if (coinSymbols.length === 0) return <p>Keine Einträge gefunden.</p>;
 
   return (
-    <div className="space-y-12">
+    <div
+      className={`space-y-12 transition-opacity duration-500 ${
+        fadeIn ? "opacity-100" : "opacity-0"
+      }`}
+    >
       <div className="card p-4 space-y-4">
         <ul className="space-y-4">
           {holdings.map((h) => {

--- a/components/PriceChart.tsx
+++ b/components/PriceChart.tsx
@@ -109,11 +109,6 @@ export default function PriceChart({ coinId }: Props) {
 
   if (!isVisible) return <div ref={ref} style={{ minHeight: "200px" }} />;
 
-  if (loading) return <p className="text-sm text-gray-400">🔄 Lade Chart...</p>;
-  if (error) return <p className="text-red-500 text-sm">⚠️ {error}</p>;
-  if (!chartData || !chartData.labels?.length)
-    return <p className="text-sm text-gray-400">Keine Daten verfügbar.</p>;
-
   return (
     <div ref={ref} className="card">
       <div className="flex flex-wrap gap-2 mb-4">
@@ -135,7 +130,37 @@ export default function PriceChart({ coinId }: Props) {
       <h2 className="text-lg font-semibold mb-2">
         📈 {coinId.toUpperCase()} Chart
       </h2>
-      <Line data={chartData} />
+
+      {error ? (
+        <p className="text-red-500 text-sm transition-opacity duration-500">
+          ⚠️ {error}
+        </p>
+      ) : !chartData || !chartData.labels?.length ? (
+        loading ? (
+          <div className="h-40 bg-gray-200 dark:bg-gray-700 rounded animate-pulse transition-opacity duration-500" />
+        ) : (
+          <p className="text-sm text-gray-400 transition-opacity duration-500">
+            Keine Daten verfügbar.
+          </p>
+        )
+      ) : (
+        <div className="relative h-64">
+          <div
+            className={`transition-opacity duration-500 ${
+              loading ? "opacity-0" : "opacity-100"
+            }`}
+          >
+            <Line data={chartData} />
+          </div>
+          <div
+            className={`absolute inset-0 transition-opacity duration-500 ${
+              loading ? "opacity-100" : "opacity-0"
+            }`}
+          >
+            <div className="h-full w-full bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace loading text with Tailwind `animate-pulse` skeletons in portfolio and chart components
- Cross-fade between loaders and content using CSS opacity transitions when data changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689b22ca9a0c832990ab32b38a13ffa5